### PR TITLE
Tracking failures are not detected when overlap is not finite

### DIFF
--- a/evaluation/experiment/run_trial.m
+++ b/evaluation/experiment/run_trial.m
@@ -36,7 +36,7 @@ while start < sequence.length
 
     overlap = calculate_overlap(Tr, get_region(sequence, start:sequence.length));
 
-    failures = find(overlap' < 0.0000001);
+    failures = find(overlap' < 0.0000001 | ~isfinite(overlap'));
     failures = failures(failures > 1);
 
     trajectory(start, 4) = -1;


### PR DESCRIPTION
In run_trial.m, the criterion for detecting failures is not sufficient, as it will evaluate to false in the case when the overlap either is not a number or is infinite. I am not exactly sure if the latter case is theoretically possible (i can reproduce the nan case) but I included it anyway.
