### PR TITLE
Fixed usage of __has_include

### DIFF
--- a/tracker/examples/native/vot.h
+++ b/tracker/examples/native/vot.h
@@ -44,7 +44,7 @@
 
 // Newer compilers support interactive checks for headers, otherwise we have to enable TraX support manually
 #ifdef __has_include
-#  if __has_include(trax.h)
+#  if __has_include("trax.h")
 #    include <trax.h>
 #    define VOT_TRAX
 #  endif


### PR DESCRIPTION
While running ./build.sh I get the following error:

In file included from static.c:42:0:
vot.h:47:27: error: operator "__has_include__" requires a header string
 #  if __has_include(trax.h)
                           ^
vot.h:47:27: error: missing ')' after "__has_include__"
vot.h:47:26: error: missing binary operator before token "h"
 #  if __has_include(trax.h)
                          ^
In file included from static.cpp:39:0:
vot.h:47:27: error: operator "__has_include__" requires a header string
 #  if __has_include(trax.h)
                           ^
vot.h:47:27: error: missing ')' after "__has_include__"
vot.h:47:26: error: missing binary operator before token "h"
 #  if __has_include(trax.h)
                          ^
In file included from ncc.cpp:44:0:
vot.h:47:27: error: operator "__has_include__" requires a header string
 #  if __has_include(trax.h)
                           ^
vot.h:47:27: error: missing ')' after "__has_include__"
vot.h:47:26: error: missing binary operator before token "h"
 #  if __has_include(trax.h)



Changing __has_include(trax.h) to __has_include("trax.h") fixes this.