### PR TITLE
Fix empty matrix index for octave bug. Fix too long filename cache bug.

### DIFF
--- a/analysis/analyze_expected_overlap.m
+++ b/analysis/analyze_expected_overlap.m
@@ -70,8 +70,9 @@ function [result] = analyze_expected_overlap(experiment, trackers, sequences, va
         
         sequences_hash = calculate_results_fingerprint(trackers{i}, experiment, experiment_sequences);
         
-        cache_file = fullfile(cache, 'expected_overlap', sprintf('%s_%s_%s_%s_%s_%s.mat', ...
-            trackers{i}.identifier, experiment.name, sequences_hash, lengths_hash, labels_hash, parameters_hash));
+        hash_hash = md5sum( strjoin({sequences_hash, lengths_hash, labels_hash, parameters_hash}), true);
+        cache_file = fullfile(cache, 'expected_overlap', sprintf('%s_%s_%s.mat', ...
+            trackers{i}.identifier, experiment.name, hash_hash));
 
         expected_overlaps = [];
         evaluated_lengths = [];
@@ -100,7 +101,12 @@ function [result] = analyze_expected_overlap(experiment, trackers, sequences, va
             accumulator = nan(numel(lengths), numel(labels), numel(sequences));
 
             for j = 1:numel(sequences)
-                accumulator(:, :, j) = estimate_expected_overlap(trackers{i}, experiment, sequences(j), 'Lengths', lengths, 'Labels', labels);
+                overlap = estimate_expected_overlap(trackers{i}, experiment, sequences(j), 'Lengths', lengths, 'Labels', labels);
+                if (size(overlap,1) == 0)
+                  accumulator(:, :, j) = NaN;
+                else
+                  accumulator(:, :, j) = overlap;
+                end;
             end;
 
             expected_overlaps = nanmean(accumulator, 3);


### PR DESCRIPTION
This fixes two bugs:
- a bug in octave where an assignment using an empty matrix fails.
- `run_analysis` failed because of too long cache-filenames

The latter is solved by combining all generated hashes which are used to construct a filename into a single new hash.