### PR TITLE
utilities/initialize_native.m: remove trailing whitespace/newlines from the snapshot id

### DIFF
--- a/utilities/initialize_native.m
+++ b/utilities/initialize_native.m
@@ -131,6 +131,8 @@ if current_timestamp > previous_timestamp + update_interval
         snapshot = '';
     end
 
+    snapshot = strtrim(snapshot); % Remove trailing whitespace/newline
+
     trax_hash_url = sprintf('%s%strax-%s%s.md5', native_url, snapshot, ostype, arch);
     trax_bundle_url = sprintf('%s%strax-%s%s.zip', native_url, snapshot, ostype, arch);
     trax_hash_file = fullfile(native_dir, 'trax.md5');


### PR DESCRIPTION
Because inevitably someone will create a snapshot ID file with a text editor that forces empty line at the end of the file...