### PR TITLE
Choose the first python interpreter found in PATH

### DIFF
--- a/tracker/generate_python_command.m
+++ b/tracker/generate_python_command.m
@@ -38,6 +38,7 @@ if isempty(python_exec)
     for i = 1:numel(system_paths)
         if exist(fullfile(system_paths{i}, exec_name), 'file') == 2
             python_exec = fullfile(system_paths{i}, exec_name);
+	    break;
         end
     end
 


### PR DESCRIPTION
For users who use multiple python interpreters, the default and expected interpreter is the one first found in PATH.